### PR TITLE
#30 - Add field 'of' to type Vector

### DIFF
--- a/src/ruler/core.clj
+++ b/src/ruler/core.clj
@@ -34,9 +34,8 @@
     (swap! ctx-config* assoc k value)))
 
 (defn- merge-opts [model]
-  (if-let [global-opts (:global-opts @ctx-config*)]
-    (update model :opts merge global-opts)
-    model))
+  (let [global-opts (:global-opts @ctx-config*)]
+    (update model :opts merge global-opts)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Internal implementations.

--- a/src/ruler/models.clj
+++ b/src/ruler/models.clj
@@ -21,6 +21,9 @@
   (when err
     {:key k :pred p}))
 
+(defn- type? [t v]
+  (some #(instance? % v) (type->types t)))
+
 (defn- req-key? [k]
   (contains? keys-req k))
 
@@ -68,9 +71,7 @@
   [k {:keys [key type]} data]
   (let [val (get data key)
         val? (some? val)
-        types (type->types type)
-        no-instance? (not (some #(instance? % val) types))
-        err (and val? no-instance?)]
+        err (and val? (not (type? type val)))]
     (->err err key k)))
 
 (defmethod key-validation :req
@@ -169,6 +170,13 @@
   [k {:keys [key format-fn]} data]
   (let [val (get data key)
         err (not (format-fn val))]
+    (->err err key k)))
+
+(defmethod key-validation :of
+  [k {:keys [key type of]} data]
+  (let [val (get data key)
+        err (or (not= clojure.lang.IPersistentVector type)
+                (not-every? #(type? of %) val))]
     (->err err key k)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/ruler/rules.clj
+++ b/src/ruler/rules.clj
@@ -46,7 +46,8 @@
    :max-length  integer?
    :contains    vec-or-set
    :format      regex?
-   :format-fn   fn?})
+   :format-fn   fn?
+   :of          allowed-type?})
 
 (def key->type-text
   {:key         "Keyword"
@@ -63,7 +64,8 @@
    :max-length  "Integer"
    :contains    "Vector or Set"
    :format      "Regex"
-   :format-fn   "Function"})
+   :format-fn   "Function"
+   :of          "'allowed-types'. Check docs for more information"})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Rules.

--- a/test/ruler/models_test.clj
+++ b/test/ruler/models_test.clj
@@ -46,11 +46,20 @@
    :min -9999
    :max 9999})
 
+(def test-rule3
+  {:key :test
+   :type clojure.lang.IPersistentVector
+   :req true
+   :of Integer})
+
 (def test-data
   {:test "string"})
 
 (def test-data2
   {:test 12})
+
+(def test-data3
+  {:test [1 2]})
 
 (def test-model [{:key :name :type String :required true}])
 
@@ -70,7 +79,8 @@
     (is (nil? (models/key-validation :length      test-rule test-data))   ":length")
     (is (nil? (models/key-validation :contains    test-rule test-data))   ":contains")
     (is (nil? (models/key-validation :format      test-rule test-data))   ":format")
-    (is (nil? (models/key-validation :format-fn   test-rule test-data))   ":format-fn"))
+    (is (nil? (models/key-validation :format-fn   test-rule test-data))   ":format-fn")
+    (is (nil? (models/key-validation :of          test-rule3 test-data3)) ":of"))
 
   (testing "Invalid data value"
     (is (= {:key :test :pred :type}        (models/key-validation :type        test-rule   {:test 1.1})) ":type")
@@ -86,7 +96,8 @@
     (is (= {:key :test :pred :length}      (models/key-validation :length      test-rule   {:test "ble"})) ":length")
     (is (= {:key :test :pred :contains}    (models/key-validation :contains    test-rule   {:test "bli"})) ":contains")
     (is (= {:key :test :pred :format}      (models/key-validation :format      test-rule   {:test "blu"})) ":format")
-    (is (= {:key :test :pred :format-fn}   (models/key-validation :format-fn   (assoc test-rule :format-fn (fn [_] false)) {:test "teste"})) ":format-fn")))
+    (is (= {:key :test :pred :format-fn}   (models/key-validation :format-fn   (assoc test-rule :format-fn (fn [_] false)) {:test "teste"})) ":format-fn")
+    (is (= {:key :test :pred :of}          (models/key-validation :of          test-rule3  {:test ["blu"]})) ":of")))
 
 (deftest opt-key-validation-test
 

--- a/test/ruler/rules_test.clj
+++ b/test/ruler/rules_test.clj
@@ -24,7 +24,8 @@
     (is (nil? (rules/check-rule {:key :name :type String :contains [1 2]})) "With optional field: contains")
     (is (nil? (rules/check-rule {:key :name :type String :contains #{"1" "2"}})) "With optional field: contains")
     (is (nil? (rules/check-rule {:key :name :type String :format #"\d{4}"})) "With optional field: format")
-    (is (nil? (rules/check-rule {:key :name :type String :format-fn (fn [_] true)})) "With optional field: format-fn"))
+    (is (nil? (rules/check-rule {:key :name :type String :format-fn (fn [_] true)})) "With optional field: format-fn")
+    (is (nil? (rules/check-rule {:key :name :type rules/Vector :of String})) "With optional field: of"))
 
   (testing "Invalid rules"
     (is (thrown? java.lang.AssertionError (rules/check-rule {})) "Missing required fields")
@@ -42,4 +43,6 @@
     (is (thrown? java.lang.AssertionError (rules/check-rule {:key :name :type Integer :max-length "99"})) "Invalid values for field: max-length")
     (is (thrown? java.lang.AssertionError (rules/check-rule {:key :name :type Integer :contains some?})) "Invalid values for field: contains")
     (is (thrown? java.lang.AssertionError (rules/check-rule {:key :name :type Integer :format {:test 1}})) "Invalid values for field: format")
-    (is (thrown? java.lang.AssertionError (rules/check-rule {:key :name :type Integer :format-fn 1})) "Invalid values for field: format-fn")))
+    (is (thrown? java.lang.AssertionError (rules/check-rule {:key :name :type Integer :format-fn 1})) "Invalid values for field: format-fn")
+    (is (thrown? java.lang.AssertionError (rules/check-rule {:key :name :type rules/Vector :of "1"})) "Invalid values for field: of")
+    (is (thrown? java.lang.AssertionError (rules/check-rule {:key :name :type String :of "1"})) "Invalid values for field: of")))

--- a/test/ruler/rules_test.clj
+++ b/test/ruler/rules_test.clj
@@ -45,4 +45,4 @@
     (is (thrown? java.lang.AssertionError (rules/check-rule {:key :name :type Integer :format {:test 1}})) "Invalid values for field: format")
     (is (thrown? java.lang.AssertionError (rules/check-rule {:key :name :type Integer :format-fn 1})) "Invalid values for field: format-fn")
     (is (thrown? java.lang.AssertionError (rules/check-rule {:key :name :type rules/Vector :of "1"})) "Invalid values for field: of")
-    (is (thrown? java.lang.AssertionError (rules/check-rule {:key :name :type String :of "1"})) "Invalid values for field: of")))
+    (is (thrown? java.lang.AssertionError (rules/check-rule {:key :name :type String :of "1"})) "Invalid :type to use with :of")))


### PR DESCRIPTION
Now you can define the allowed type to Vector, example:
vector of strings = {:type Vector :of String}